### PR TITLE
docs: Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Welcome to Minecraft-MCP-Server contributing guide
+
+## Prerequisites
+- Git
+- Node.js (>=16.0.0)
+- A running Minecraft game (the setup below was tested with Minecraft 1.21.4 Java Edition included in Microsoft Game Pass)
+- Claude Desktop
+
+## Getting Started
+This bot is designed to be used with Claude Desktop through the Model Context Protocol (MCP).
+
+### 1. Setup Minecraft Server
+Create a singleplayer world and open it to LAN (ESC -> Open to LAN). Bot will try to connect using port 25565 and hostname localhost. These parameters could be configured in claude_desktop_config.json on a next step.
+
+### 2. MCP Configuration
+
+Make sure that [Claude Desktop](https://claude.ai/download) is installed. 
+
+You can open your desktop config file via Claude Desktop by clicking `File -> Settings -> Developer -> Edit Config`.
+
+You can also open your Claude for Desktop App configuration via text editor by typing in the command line:
+
+**MacOS/Linux**
+```
+code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+**Windows**
+```
+code $env:AppData\Claude\claude_desktop_config.json
+```
+
+Update your `claude_desktop_config.json` by adding the minecraft mcp server in the mcpServers key, or adding if there is none. For this project, you can copy and paste the following code:
+
+If you're running from this github repository, you can add this:
+
+```json
+{
+  "mcpServers": {
+    "minecraft": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:yuniko-software/minecraft-mcp-server",
+        "--host",
+        "localhost",
+        "--port",
+        "25565",
+        "--username",
+        "ClaudeBot"
+      ]
+    }
+  }
+}
+```
+
+If you're running from your local repository:
+
+Install npm dependecies
+```
+npm install
+```
+
+Build the Typescript
+```
+npm run build
+```
+
+There should be an javascript file in `dist/` called `bot.js`. 
+
+You can have Claude run this multiple ways.
+
+#### Running with npx
+Help needed
+
+
+#### Running with nvm
+There is an [ongoing issue](https://github.com/modelcontextprotocol/servers/issues/64) with MCP servers and Node Version Manager, where Claude seems to use an incompatible version when hosting this codebase.
+
+To bypass this, you can run this command and use the specified path for the command field.
+```
+which node
+```
+
+Be sure to copy and paste the path of `/dist/bot.js`.
+
+```json
+{
+  "mcpServers": {
+    "minecraft": {
+      "command": "/Users/[username]/.nvm/versions/node/v23.3.0/bin/node",
+      "args": [
+        "/PATH/TO/YOUR/FORKED/REPOSITORY/dist/bot.js",
+        "--host",
+        "localhost",
+        "--port",
+        "25565",
+        "--username",
+        "ClaudeBot"
+      ]
+    }
+  }
+}
+```
+
+Double-check that right `--port` and `--host` parameters were used. Make sure to completely reboot the Claude Desktop application (should be closed in OS tray).
+
+Once you open Claude, the MCP server should start automatically and your bot should connect to the configured Minecraft server (if it's running). You'll then be able to control the bot through Claude's chat interface.

--- a/README.md
+++ b/README.md
@@ -109,3 +109,5 @@ Feel free to submit pull requests or open issues for improvements. Some areas th
 - More robust error handling
 - Tests for different components
 - New functionality and commands
+
+To get started with contributing, please see [CONTRIBUTING.md](https://github.com/yuniko-software/minecraft-mcp-server/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Changes:
- Added CONTRIBUTING.md file for environment setup
- Includes NVM/Node.js version troubleshooting for MCP

I had a bit of trouble setting up the dev environment for this MCP server so I added a contrib doc for any future contributors. I added the node setup because I couldn't figure out how to debug my npx setup in `claude_desktop_config.json`. My Claude Desktop kept returning error logs like:

```
25-06-03T03:13:49.037Z [minecraft] [info] Initializing server...
2025-06-03T03:13:49.084Z [minecraft] [info] Server started and connected successfully
2025-06-03T03:13:49.091Z [minecraft] [info] Message from client: {"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude-ai","version":"0.1.0"}},"jsonrpc":"2.0","id":0}
Your node version is currently 16.16.0
Please update it to a version >= 22.x.x from https://nodejs.org/
2025-06-03T03:13:49.386Z [minecraft] [info] Server transport closed
2025-06-03T03:13:49.386Z [minecraft] [info] Client transport closed
2025-06-03T03:13:49.386Z [minecraft] [info] Server transport closed unexpectedly, this is likely due to the process exiting early. If you are developing this MCP server you can add output to stderr (i.e. console.error('...') in JavaScript, print('...', file=sys.stderr) in python) and it will appear in this log.
2025-06-03T03:13:49.386Z [minecraft] [error] Server disconnected. For troubleshooting guidance, please visit our [debugging documentation](https://modelcontextprotocol.io/docs/tools/debugging) {"context":"connection"}
2025-06-03T03:13:49.387Z [minecraft] [info] Client transport closed
```

My `node -v` returned `v23.3.0`. I stumbled across [this issue](https://github.com/modelcontextprotocol/servers/issues/64) in the MCP repo, so I think this is ongoing for the client Claude, not this MCP server itself (which is why I didn't submit an issue instead). I used the OPs resolution for the setup. Otherwise, feel free to put in what works. 

Thanks ^_^