### PR TITLE
feat: add secure container deployment, GHCR release workflow, and dual MCP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+node_modules
+dist
+npm-debug.log*
+.env
+.env.*
+coverage
+tests
+.DS_Store

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,0 +1,50 @@
+name: Release Container
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=sha,prefix=sha-
+
+      - name: Build and push container image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:24-bookworm-slim AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --ignore-scripts
+
+COPY tsconfig*.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:24-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+COPY --chown=node:node --from=build /app/dist ./dist
+
+USER node
+
+EXPOSE 3001
+
+ENTRYPOINT ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,87 @@ Using Claude Sonnet could give you some interesting results. The bot-agent would
 
 Example usage: [shared Claude chat](https://claude.ai/share/535d5f69-f102-4cdb-9801-f74ea5709c0b)
 
+## Configuration
+
+The server supports both inline CLI arguments and environment variables:
+
+- `--host` or `MINECRAFT_HOST` (default: `localhost`)
+- `--port` or `MINECRAFT_PORT` (default: `25565`)
+- `--username` or `MINECRAFT_USERNAME` (default: `LLMBot`)
+- `--keep-alive-without-client` or `MCP_KEEP_ALIVE_WITHOUT_CLIENT` (default: `false`)
+- `--transport` or `MCP_TRANSPORT` (`stdio` or `http`, default: `stdio`)
+- `--mcp-http-host` or `MCP_HTTP_HOST` (default: `0.0.0.0`)
+- `--mcp-http-port` or `MCP_HTTP_PORT` (default: `3001`)
+- `--mcp-http-path` or `MCP_HTTP_PATH` (default: `/mcp`)
+
+Inline CLI arguments take precedence over environment variables. This keeps Claude Desktop `args` configuration fully compatible while allowing easier container deployments.
+
+### Container Build and Runtime Variables
+
+Build-time:
+
+- No Minecraft-specific environment variables are required to build the image.
+- For the GitHub Release workflow, no extra secrets are required beyond the default `GITHUB_TOKEN` (used for GHCR publish).
+
+Runtime (optional):
+
+- `MINECRAFT_HOST` (default: `localhost`)
+- `MINECRAFT_PORT` (default: `25565`)
+- `MINECRAFT_USERNAME` (default: `LLMBot`)
+- `MCP_KEEP_ALIVE_WITHOUT_CLIENT` (default: `false`)
+- `MCP_TRANSPORT` (default: `stdio`)
+- `MCP_HTTP_HOST` (default: `0.0.0.0`)
+- `MCP_HTTP_PORT` (default: `3001`)
+- `MCP_HTTP_PATH` (default: `/mcp`)
+
+Example container run with env vars:
+
+```bash
+docker run --rm -i \
+  -e MINECRAFT_HOST=host.docker.internal \
+  -e MINECRAFT_PORT=25565 \
+  -e MINECRAFT_USERNAME=LLMBot \
+  -e MCP_KEEP_ALIVE_WITHOUT_CLIENT=true \
+  ghcr.io/yuniko-software/minecraft-mcp-server:latest
+```
+
+You can still pass inline args instead (and they will override env vars):
+
+```bash
+docker run --rm -i ghcr.io/yuniko-software/minecraft-mcp-server:latest \
+  --host host.docker.internal --port 25565 --username ClaudeBot
+```
+
+Run as remote MCP server over HTTP:
+
+```bash
+docker run -d --name minecraft-mcp-remote \
+  -p 3001:3001 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_PORT=3001 \
+  -e MCP_HTTP_PATH=/mcp \
+  -e MINECRAFT_HOST=host.docker.internal \
+  -e MINECRAFT_PORT=25565 \
+  -e MINECRAFT_USERNAME=ClaudeBot \
+  ghcr.io/yuniko-software/minecraft-mcp-server:latest
+```
+
+Example MCP client configuration for remote mode:
+
+```json
+{
+  "mcp": {
+    "minecraft_remote": {
+      "type": "remote",
+      "url": "http://127.0.0.1:3001/mcp",
+      "enabled": true,
+      "timeout": 15000
+    }
+  }
+}
+```
+
 ## Available Commands
 
 Once connected to a Minecraft server, Claude can use these commands:

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,26 +5,138 @@ export interface ServerConfig {
   host: string;
   port: number;
   username: string;
+  keepAliveWithoutClient: boolean;
+  transport: 'stdio' | 'http';
+  mcpHttpHost: string;
+  mcpHttpPort: number;
+  mcpHttpPath: string;
+}
+
+const DEFAULT_HOST = 'localhost';
+const DEFAULT_PORT = 25565;
+const DEFAULT_USERNAME = 'LLMBot';
+const DEFAULT_KEEP_ALIVE_WITHOUT_CLIENT = false;
+const DEFAULT_MCP_TRANSPORT: ServerConfig['transport'] = 'stdio';
+const DEFAULT_MCP_HTTP_HOST = '0.0.0.0';
+const DEFAULT_MCP_HTTP_PORT = 3001;
+const DEFAULT_MCP_HTTP_PATH = '/mcp';
+
+function getPortFromEnv(): number {
+  const envPort = process.env.MINECRAFT_PORT;
+  if (!envPort) {
+    return DEFAULT_PORT;
+  }
+
+  const parsedPort = Number(envPort);
+  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+    return DEFAULT_PORT;
+  }
+
+  return parsedPort;
+}
+
+function getMcpHttpPortFromEnv(): number {
+  const envPort = process.env.MCP_HTTP_PORT;
+  if (!envPort) {
+    return DEFAULT_MCP_HTTP_PORT;
+  }
+
+  const parsedPort = Number(envPort);
+  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+    return DEFAULT_MCP_HTTP_PORT;
+  }
+
+  return parsedPort;
+}
+
+function getTransportFromEnv(): ServerConfig['transport'] {
+  const envTransport = process.env.MCP_TRANSPORT;
+  if (envTransport === 'http' || envTransport === 'stdio') {
+    return envTransport;
+  }
+
+  return DEFAULT_MCP_TRANSPORT;
+}
+
+function normalizeHttpPath(path: string): string {
+  if (!path.trim()) {
+    return DEFAULT_MCP_HTTP_PATH;
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function getBooleanFromEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
 }
 
 export function parseConfig(): ServerConfig {
-  return yargs(hideBin(process.argv))
+  const parsed = yargs(hideBin(process.argv))
     .option('host', {
       type: 'string',
       description: 'Minecraft server host',
-      default: 'localhost'
+      default: process.env.MINECRAFT_HOST ?? DEFAULT_HOST
     })
     .option('port', {
       type: 'number',
       description: 'Minecraft server port',
-      default: 25565
+      default: getPortFromEnv()
     })
     .option('username', {
       type: 'string',
       description: 'Bot username',
-      default: 'LLMBot'
+      default: process.env.MINECRAFT_USERNAME ?? DEFAULT_USERNAME
+    })
+    .option('keep-alive-without-client', {
+      type: 'boolean',
+      description: 'Keep running when MCP stdio client disconnects',
+      default: getBooleanFromEnv(process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT, DEFAULT_KEEP_ALIVE_WITHOUT_CLIENT)
+    })
+    .option('transport', {
+      choices: ['stdio', 'http'] as const,
+      description: 'MCP transport mode',
+      default: getTransportFromEnv()
+    })
+    .option('mcp-http-host', {
+      type: 'string',
+      description: 'MCP HTTP transport listen host',
+      default: process.env.MCP_HTTP_HOST ?? DEFAULT_MCP_HTTP_HOST
+    })
+    .option('mcp-http-port', {
+      type: 'number',
+      description: 'MCP HTTP transport listen port',
+      default: getMcpHttpPortFromEnv()
+    })
+    .option('mcp-http-path', {
+      type: 'string',
+      description: 'MCP HTTP transport route path',
+      default: normalizeHttpPath(process.env.MCP_HTTP_PATH ?? DEFAULT_MCP_HTTP_PATH)
     })
     .help()
     .alias('help', 'h')
+    .coerce('mcp-http-path', normalizeHttpPath)
     .parseSync();
+
+  return {
+    host: parsed.host,
+    port: parsed.port,
+    username: parsed.username,
+    keepAliveWithoutClient: parsed.keepAliveWithoutClient,
+    transport: parsed.transport,
+    mcpHttpHost: parsed.mcpHttpHost,
+    mcpHttpPort: parsed.mcpHttpPort,
+    mcpHttpPath: parsed.mcpHttpPath ?? DEFAULT_MCP_HTTP_PATH
+  };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { setupStdioFiltering } from './stdio-filter.js';
 import { log } from './logger.js';
 import { parseConfig } from './config.js';
@@ -18,7 +23,24 @@ import { registerGameStateTools } from './tools/gamestate-tools.js';
 import { registerCraftingTools } from './tools/crafting-tools.js';
 import { registerFurnaceTools } from './tools/furnace-tools.js';
 
-setupStdioFiltering();
+interface HttpSession {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+type HttpRequest = IncomingMessage & { body?: unknown };
+
+function writeJson(res: ServerResponse, statusCode: number, payload: unknown): void {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(payload));
+}
+
+function writeText(res: ServerResponse, statusCode: number, message: string): void {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.end(message);
+}
 
 process.on('unhandledRejection', (reason) => {
   log('error', `Unhandled rejection: ${reason}`);
@@ -28,23 +50,10 @@ process.on('uncaughtException', (error) => {
   log('error', `Uncaught exception: ${error}`);
 });
 
-async function main() {
-  const config = parseConfig();
-  const messageStore = new MessageStore();
-
-  const connection = new BotConnection(
-    config,
-    {
-      onLog: log,
-      onChatMessage: (username, message) => messageStore.addMessage(username, message)
-    }
-  );
-
-  connection.connect();
-
+function createMcpServer(connection: BotConnection, messageStore: MessageStore): McpServer {
   const server = new McpServer({
-    name: "minecraft-mcp-server",
-    version: "2.0.4"
+    name: 'minecraft-mcp-server',
+    version: '2.0.4'
   });
 
   const factory = new ToolFactory(server, connection);
@@ -60,14 +69,197 @@ async function main() {
   registerCraftingTools(factory, getBot);
   registerFurnaceTools(factory, getBot);
 
-  process.stdin.on('end', () => {
+  return server;
+}
+
+async function closeHttpSessions(sessions: Record<string, HttpSession>): Promise<void> {
+  const sessionEntries = Object.entries(sessions);
+  for (const [sessionId, session] of sessionEntries) {
+    try {
+      await session.server.close();
+    } catch (error) {
+      log('warn', `Failed to close MCP server for session ${sessionId}: ${String(error)}`);
+    }
+
+    try {
+      await session.transport.close();
+    } catch (error) {
+      log('warn', `Failed to close transport for session ${sessionId}: ${String(error)}`);
+    }
+
+    delete sessions[sessionId];
+  }
+}
+
+async function main() {
+  const config = parseConfig();
+  const messageStore = new MessageStore();
+
+  const connection = new BotConnection(
+    config,
+    {
+      onLog: log,
+      onChatMessage: (username, message) => messageStore.addMessage(username, message)
+    }
+  );
+
+  connection.connect();
+
+  if (config.transport === 'stdio') {
+    setupStdioFiltering();
+
+    const server = createMcpServer(connection, messageStore);
+
+    process.stdin.on('end', () => {
+      if (config.keepAliveWithoutClient) {
+        log('info', 'MCP Client has disconnected. keep-alive mode is enabled; server will continue running.');
+        return;
+      }
+
+      connection.cleanup();
+      log('info', 'MCP Client has disconnected. Shutting down...');
+      process.exit(0);
+    });
+
+    process.on('SIGTERM', async () => {
+      await server.close();
+      connection.cleanup();
+      log('info', 'SIGTERM received. Shutting down...');
+      process.exit(0);
+    });
+
+    process.on('SIGINT', async () => {
+      await server.close();
+      connection.cleanup();
+      log('info', 'SIGINT received. Shutting down...');
+      process.exit(0);
+    });
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    return;
+  }
+
+  const app = createMcpExpressApp({ host: config.mcpHttpHost });
+  const sessions: Record<string, HttpSession> = {};
+
+  app.post(config.mcpHttpPath, async (req: HttpRequest, res: ServerResponse) => {
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+    try {
+      if (sessionId && sessions[sessionId]) {
+        await sessions[sessionId].transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (!sessionId && isInitializeRequest(req.body)) {
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (initializedSessionId) => {
+            sessions[initializedSessionId] = {
+              server,
+              transport
+            };
+          }
+        });
+
+        const server = createMcpServer(connection, messageStore);
+
+        transport.onclose = () => {
+          if (transport.sessionId) {
+            delete sessions[transport.sessionId];
+          }
+          void server.close();
+        };
+
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      writeJson(res, 400, {
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: No valid session ID provided'
+        },
+        id: null
+      });
+    } catch (error) {
+      log('error', `HTTP MCP POST handler error: ${String(error)}`);
+      if (!res.headersSent) {
+        writeJson(res, 500, {
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal server error'
+          },
+          id: null
+        });
+      }
+    }
+  });
+
+  app.get(config.mcpHttpPath, async (req: HttpRequest, res: ServerResponse) => {
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+    if (!sessionId || !sessions[sessionId]) {
+      writeText(res, 400, 'Invalid or missing session ID');
+      return;
+    }
+
+    await sessions[sessionId].transport.handleRequest(req, res);
+  });
+
+  app.delete(config.mcpHttpPath, async (req: HttpRequest, res: ServerResponse) => {
+    const sessionIdHeader = req.headers['mcp-session-id'];
+    const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+
+    if (!sessionId || !sessions[sessionId]) {
+      writeText(res, 400, 'Invalid or missing session ID');
+      return;
+    }
+
+    await sessions[sessionId].transport.handleRequest(req, res);
+  });
+
+  const httpServer = app.listen(config.mcpHttpPort, config.mcpHttpHost, () => {
+    log('info', `MCP HTTP server listening on http://${config.mcpHttpHost}:${config.mcpHttpPort}${config.mcpHttpPath}`);
+  });
+
+  process.on('SIGTERM', async () => {
+    await closeHttpSessions(sessions);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
     connection.cleanup();
-    log('info', 'MCP Client has disconnected. Shutting down...');
+    log('info', 'SIGTERM received. Shutting down...');
     process.exit(0);
   });
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  process.on('SIGINT', async () => {
+    await closeHttpSessions(sessions);
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    connection.cleanup();
+    log('info', 'SIGINT received. Shutting down...');
+    process.exit(0);
+  });
 }
 
 main().catch((error) => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,79 +1,200 @@
 import test from 'ava';
 import { parseConfig } from '../src/config.js';
 
-test('parseConfig returns default values', (t) => {
-  const originalArgv = process.argv;
+const ORIGINAL_ARGV = process.argv;
+const ORIGINAL_ENV = {
+  host: process.env.MINECRAFT_HOST,
+  port: process.env.MINECRAFT_PORT,
+  username: process.env.MINECRAFT_USERNAME,
+  keepAliveWithoutClient: process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT,
+  transport: process.env.MCP_TRANSPORT,
+  mcpHttpHost: process.env.MCP_HTTP_HOST,
+  mcpHttpPort: process.env.MCP_HTTP_PORT,
+  mcpHttpPath: process.env.MCP_HTTP_PATH
+};
+
+test.beforeEach(() => {
   process.argv = ['node', 'script.js'];
-  
+  delete process.env.MINECRAFT_HOST;
+  delete process.env.MINECRAFT_PORT;
+  delete process.env.MINECRAFT_USERNAME;
+  delete process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT;
+  delete process.env.MCP_TRANSPORT;
+  delete process.env.MCP_HTTP_HOST;
+  delete process.env.MCP_HTTP_PORT;
+  delete process.env.MCP_HTTP_PATH;
+});
+
+test.after.always(() => {
+  process.argv = ORIGINAL_ARGV;
+  if (ORIGINAL_ENV.host === undefined) {
+    delete process.env.MINECRAFT_HOST;
+  } else {
+    process.env.MINECRAFT_HOST = ORIGINAL_ENV.host;
+  }
+  if (ORIGINAL_ENV.port === undefined) {
+    delete process.env.MINECRAFT_PORT;
+  } else {
+    process.env.MINECRAFT_PORT = ORIGINAL_ENV.port;
+  }
+  if (ORIGINAL_ENV.username === undefined) {
+    delete process.env.MINECRAFT_USERNAME;
+  } else {
+    process.env.MINECRAFT_USERNAME = ORIGINAL_ENV.username;
+  }
+  if (ORIGINAL_ENV.keepAliveWithoutClient === undefined) {
+    delete process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT;
+  } else {
+    process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT = ORIGINAL_ENV.keepAliveWithoutClient;
+  }
+  if (ORIGINAL_ENV.transport === undefined) {
+    delete process.env.MCP_TRANSPORT;
+  } else {
+    process.env.MCP_TRANSPORT = ORIGINAL_ENV.transport;
+  }
+  if (ORIGINAL_ENV.mcpHttpHost === undefined) {
+    delete process.env.MCP_HTTP_HOST;
+  } else {
+    process.env.MCP_HTTP_HOST = ORIGINAL_ENV.mcpHttpHost;
+  }
+  if (ORIGINAL_ENV.mcpHttpPort === undefined) {
+    delete process.env.MCP_HTTP_PORT;
+  } else {
+    process.env.MCP_HTTP_PORT = ORIGINAL_ENV.mcpHttpPort;
+  }
+  if (ORIGINAL_ENV.mcpHttpPath === undefined) {
+    delete process.env.MCP_HTTP_PATH;
+  } else {
+    process.env.MCP_HTTP_PATH = ORIGINAL_ENV.mcpHttpPath;
+  }
+});
+
+test.serial('parseConfig returns default values', (t) => {
   const config = parseConfig();
-  
+
   t.is(config.host, 'localhost');
   t.is(config.port, 25565);
   t.is(config.username, 'LLMBot');
-  
-  process.argv = originalArgv;
+  t.false(config.keepAliveWithoutClient);
+  t.is(config.transport, 'stdio');
+  t.is(config.mcpHttpHost, '0.0.0.0');
+  t.is(config.mcpHttpPort, 3001);
+  t.is(config.mcpHttpPath, '/mcp');
 });
 
-test('parseConfig parses custom host', (t) => {
-  const originalArgv = process.argv;
+test.serial('parseConfig parses custom host', (t) => {
   process.argv = ['node', 'script.js', '--host', 'example.com'];
-  
+
   const config = parseConfig();
-  
+
   t.is(config.host, 'example.com');
   t.is(config.port, 25565);
   t.is(config.username, 'LLMBot');
-  
-  process.argv = originalArgv;
 });
 
-test('parseConfig parses custom port', (t) => {
-  const originalArgv = process.argv;
+test.serial('parseConfig parses custom port', (t) => {
   process.argv = ['node', 'script.js', '--port', '12345'];
-  
+
   const config = parseConfig();
-  
+
   t.is(config.host, 'localhost');
   t.is(config.port, 12345);
   t.is(config.username, 'LLMBot');
-  
-  process.argv = originalArgv;
 });
 
-test('parseConfig parses custom username', (t) => {
-  const originalArgv = process.argv;
+test.serial('parseConfig parses custom username', (t) => {
   process.argv = ['node', 'script.js', '--username', 'CustomBot'];
-  
+
   const config = parseConfig();
-  
+
   t.is(config.host, 'localhost');
   t.is(config.port, 25565);
   t.is(config.username, 'CustomBot');
-  
-  process.argv = originalArgv;
 });
 
-test('parseConfig parses all custom options', (t) => {
-  const originalArgv = process.argv;
+test.serial('parseConfig parses all custom options', (t) => {
   process.argv = ['node', 'script.js', '--host', 'server.net', '--port', '9999', '--username', 'TestBot'];
-  
+
   const config = parseConfig();
-  
+
   t.is(config.host, 'server.net');
   t.is(config.port, 9999);
   t.is(config.username, 'TestBot');
-  
-  process.argv = originalArgv;
 });
 
-test('parseConfig handles numeric port as number type', (t) => {
-  const originalArgv = process.argv;
+test.serial('parseConfig handles numeric port as number type', (t) => {
   process.argv = ['node', 'script.js', '--port', '30000'];
-  
+
   const config = parseConfig();
-  
+
   t.is(typeof config.port, 'number');
   t.is(config.port, 30000);
-  
-  process.argv = originalArgv;
+});
+
+test.serial('parseConfig reads values from environment variables', (t) => {
+  process.env.MINECRAFT_HOST = 'env-host';
+  process.env.MINECRAFT_PORT = '25570';
+  process.env.MINECRAFT_USERNAME = 'EnvBot';
+  process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT = 'true';
+  process.env.MCP_TRANSPORT = 'http';
+  process.env.MCP_HTTP_HOST = '127.0.0.1';
+  process.env.MCP_HTTP_PORT = '4000';
+  process.env.MCP_HTTP_PATH = '/remote-mcp';
+
+  const config = parseConfig();
+
+  t.is(config.host, 'env-host');
+  t.is(config.port, 25570);
+  t.is(config.username, 'EnvBot');
+  t.true(config.keepAliveWithoutClient);
+  t.is(config.transport, 'http');
+  t.is(config.mcpHttpHost, '127.0.0.1');
+  t.is(config.mcpHttpPort, 4000);
+  t.is(config.mcpHttpPath, '/remote-mcp');
+});
+
+test.serial('parseConfig prefers inline args over environment variables', (t) => {
+  process.env.MINECRAFT_HOST = 'env-host';
+  process.env.MINECRAFT_PORT = '25570';
+  process.env.MINECRAFT_USERNAME = 'EnvBot';
+  process.argv = ['node', 'script.js', '--host', 'cli-host', '--port', '25571', '--username', 'CliBot'];
+
+  const config = parseConfig();
+
+  t.is(config.host, 'cli-host');
+  t.is(config.port, 25571);
+  t.is(config.username, 'CliBot');
+});
+
+test.serial('parseConfig falls back to default port for invalid environment port', (t) => {
+  process.env.MINECRAFT_PORT = 'not-a-number';
+
+  const config = parseConfig();
+
+  t.is(config.port, 25565);
+});
+
+test.serial('parseConfig keeps running without client when requested via inline arg', (t) => {
+  process.argv = ['node', 'script.js', '--keep-alive-without-client'];
+
+  const config = parseConfig();
+
+  t.true(config.keepAliveWithoutClient);
+});
+
+test.serial('parseConfig prefers inline keep-alive arg over env var', (t) => {
+  process.env.MCP_KEEP_ALIVE_WITHOUT_CLIENT = 'true';
+  process.argv = ['node', 'script.js', '--no-keep-alive-without-client'];
+
+  const config = parseConfig();
+
+  t.false(config.keepAliveWithoutClient);
+});
+
+test.serial('parseConfig normalizes mcp http path', (t) => {
+  process.argv = ['node', 'script.js', '--mcp-http-path', 'custom-mcp'];
+
+  const config = parseConfig();
+
+  t.is(config.mcpHttpPath, '/custom-mcp');
 });


### PR DESCRIPTION
## Summary
- add a secure multi-stage Docker image for the MCP server with non-root runtime, production-only dependencies, and a `.dockerignore`
- add GitHub Actions release workflow to build and publish container images to GHCR on `release.published` (plus manual dispatch)
- add env-based config support while preserving inline CLI args precedence for existing Claude Desktop setups
- implement dual MCP transport support: default `stdio` mode plus `http` mode (Streamable HTTP with POST/GET/DELETE session handling)
- document container runtime/build variables and remote MCP usage in the README

## Why
This enables production-grade container deployment and release publishing while keeping backward compatibility for stdio clients and adding remote MCP support for HTTP-based clients.

## Validation
- `npm run build`
- `npm test -- tests/config.test.ts` (12 passing)
- local Docker build succeeded
- HTTP mode smoke test confirmed `/mcp` endpoint reachable and bot connection to Minecraft server