### PR TITLE
Adding Bed Tools

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { registerFlightTools } from './tools/flight-tools.js';
 import { registerGameStateTools } from './tools/gamestate-tools.js';
 import { registerCraftingTools } from './tools/crafting-tools.js';
 import { registerFurnaceTools } from './tools/furnace-tools.js';
+import { registerBedTools } from "./tools/bed-tools.js";
 
 setupStdioFiltering();
 
@@ -59,6 +60,7 @@ async function main() {
   registerGameStateTools(factory, getBot);
   registerCraftingTools(factory, getBot);
   registerFurnaceTools(factory, getBot);
+  registerBedTools(factory, getBot);
 
   process.stdin.on('end', () => {
     connection.cleanup();

--- a/src/tools/bed-tools.ts
+++ b/src/tools/bed-tools.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import mineflayer from 'mineflayer';
+import { ToolFactory } from '../tool-factory.js';
+
+export function registerBedTools(factory: ToolFactory, getBot: () => mineflayer.Bot): void {
+    factory.registerTool(
+        "sleep-bed",
+        "Find a bed block nearby max distance, then make the bot sleep in bed",
+        {
+            maxDistance: z.coerce.number().int().positive().default(16).describe("Maximum search distance for a bed (default: 16)")
+        },
+        async ({ maxDistance }: { maxDistance: number }) => {
+            const bot = getBot();
+
+            const bedBlock = bot.findBlock({
+                matching: (block) => bot.isABed(block),
+                maxDistance: maxDistance
+            });
+
+            if (!bedBlock) {
+                return factory.createResponse(`No bed found within ${maxDistance} blocks`);
+            }
+
+            try {
+                await bot.sleep(bedBlock);
+                return factory.createResponse(`Successfully sleeping in bed at (${bedBlock.position.x}, ${bedBlock.position.y}, ${bedBlock.position.z})`);
+            } catch (err) {
+                return factory.createResponse(`Failed to sleep: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    );
+
+    factory.registerTool(
+        "wake-up",
+        "Wake the bot up from bed",
+        {},
+        async () => {
+            const bot = getBot();
+
+            try {
+                await bot.wake();
+                return factory.createResponse("Successfully woke up");
+            } catch (err) {
+                return factory.createResponse(`Error waking up: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+    );
+}


### PR DESCRIPTION
## Changes:

Gives the bot ability to find and sleep in bed.

`sleep-bed` will find a bed block within a max distance range defined by the agent (default 16). Then sleep when possible.
`wake-up` will wake up the bot from sleep.

---

- [x] I have read and am familiar with [CONTRIBUTING.md](CONTRIBUTING.md)
